### PR TITLE
Allow ESP root path to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,25 +14,33 @@ Keep ESPs synchronized on mirrored-disk systems
 - rsync
 - coreutils (ln, mktemp)
 - util-linux (mountpoint, findmnt)
-- selinux-policy-devel (needed by sepolicy\_install)
+- selinux-policy-devel (needed by 'sepolicy\_install')
+- gettext (envsubst - needed by 'install')
 
 # Installation
 
-These scripts expect that the ESPs to be kept synchronized are mounted to directories named /boot@? where the question mark (?) is a single character in the range [a-z] that is unique to each ESP. The distinguishing character could, for example, correlate with the lettering of the corresponding SCSI disk device nodes that the ESPs are stored on (i.e. /dev/sda1 -> /boot@a, /dev/sdb1 -> /boot@b, etc.). Setting up such a correlation is just a recommendation. Only the pattern for the directory name matters. Where the /boot@? directories actually mount from is irrelevant to the scripts.
+The Makefile assumes that the path '/boot' is the base for all ESP-related operations; if the system has the ESP mounted at a different location, such as '/efi' or even '/boot/efi', this can be specified when the Makefile is invoked (see instructions below). The remainder of the instructions use `ESP_ROOT` as a placeholder for the specified path.
 
-The /boot@? mountpoints are expected to be available early in the system start up process. This is usually accomplished by listing the mounts in the /etc/fstab system configuration file. For example, your /etc/fstab file might contain lines like the following:
+These scripts expect that the ESPs to be kept synchronized are mounted to directories named ESP_ROOT@? where the question mark (?) is a single character in the range [a-z] that is unique to each ESP. The distinguishing character could, for example, correlate with the lettering of the corresponding SCSI disk device nodes that the ESPs are stored on (i.e. /dev/sda1 -> ESP_ROOT@a, /dev/sdb1 -> ESP_ROOT@b, etc.). Setting up such a correlation is just a recommendation. Only the pattern for the directory name matters. Where the ESP_ROOT@? directories actually mount from is irrelevant to the scripts.
 
-    PARTLABEL=boot@a /boot@a vfat umask=0077,shortname=lower,context=system_u:object_r:boot_t:s0,x-systemd.before=bootbind.service,nofail 0 0
-    PARTLABEL=boot@b /boot@b vfat umask=0077,shortname=lower,context=system_u:object_r:boot_t:s0,x-systemd.before=bootbind.service,nofail 0 0
+The ESP_ROOT@? mountpoints are expected to be available early in the system start up process. This is usually accomplished by listing the mounts in the /etc/fstab system configuration file. For example, your /etc/fstab file might contain lines like the following:
 
-**IMPORTANT**: The /etc/fstab entries for the /boot@[a-z] mountpoints *must* list `x-systemd.before=bootbind.service` as a mount option.
+    PARTLABEL=boot@a ESP_ROOT@a vfat umask=0077,shortname=lower,context=system_u:object_r:boot_t:s0,x-systemd.before=bootbind.service,nofail 0 0
+    PARTLABEL=boot@b ESP_ROOT@b vfat umask=0077,shortname=lower,context=system_u:object_r:boot_t:s0,x-systemd.before=bootbind.service,nofail 0 0
 
-The /boot directory should be empty and unmounted. These scripts will bind-mount /boot to whichever ESP is currently being used on system start up. You can disable the bootbind systemd service and maintain the mount yourself if you wish, but /boot must be a bind mount to one of the /boot@[a-z] mountpoints.
+**IMPORTANT**: The /etc/fstab entries for the ESP_ROOT@[a-z] mountpoints *must* list `x-systemd.before=bootbind.service` as a mount option.
 
-Once the mountpoints are configured as the scripts expect, the scripts can be copied into place and enabled. A makefile is provide to automate the installation process. To install the scripts and the selinux policy using the makefile, run the following commands while in the root of the git repository:
+The ESP_ROOT directory should be empty and unmounted. These scripts will bind-mount ESP_ROOT to whichever ESP is currently being used on system start up. You can disable the bootbind systemd service and maintain the mount yourself if you wish, but ESP_ROOT must be a bind mount to one of the ESP_ROOT@[a-z] mountpoints.
+
+Once the mountpoints are configured as the scripts expect, the scripts can be copied into place and enabled. A makefile is provide to automate the installation process. To install the scripts and the selinux policy using the makefile, with the default ESP_ROOT path of /boot, run the following commands while in the root of the git repository:
 
     $ sudo make install
     $ sudo make sepolicy_install
+
+To install the scripts and the selinux policy using the makefile, with a specified ESP_ROOT path of /efi, run the following commands while in the root of the git repository:
+
+    $ sudo make install esp_root=/efi
+    $ sudo make sepolicy_install esp_root=/efi
 
 # How it works
 
@@ -40,7 +48,7 @@ This software consists of two Bash scripts and two corresponding systemd service
 
 Only paths matching the machine id of the currently booted OS are copied from the current ESP to the secondary ESP(s). This sould be sufficient to synchronize the kernel, initramfs, and BLS loader entries across the ESPs. The currently booted OS's machine id is obtained from /etc/machine-id. The recommended way to synchronize other ESP content is to call `booctl update --esp-path=...` manually when necessary.
 
-The Bash scripts are stored in /etc/bootsync. One is named `bootbind`. It bind mounts one of the /boot@[a-z] mountpoints onto /boot. The other is named `bootsync`. It calls rsync after performing a few basic safety checks. The Bash scripts can be run manually with sudo. They do not take any parameters. In fact, I recommend running them manually once right after they are installed to be sure that they are working properly. I also recommend making a backup copy of your ESPs before running them for the first time just to be safe.
+The Bash scripts are stored in /etc/bootsync. One is named `bootbind`. It bind mounts one of the ESP_ROOT@[a-z] mountpoints onto ESP_ROOT. The other is named `bootsync`. It calls rsync after performing a few basic safety checks. The Bash scripts can be run manually with sudo. They do not take any parameters. In fact, I recommend running them manually once right after they are installed to be sure that they are working properly. I also recommend making a backup copy of your ESPs before running them for the first time just to be safe.
 
 Note that when calling the `bootsync` command manually with selinux enabled, it will be running in a different selinux context than it does when called by the systemd startup scripts. Your selinux rules may block running the scripts manually depending on what permissive domains you have configured. You might need to temporarily set the *rsync\_t* domain to permissive mode to run the `bootsync` command from the command line. Basically, do the following to test `bootsync` manually with selinux enabled:
 
@@ -51,7 +59,7 @@ Note that when calling the `bootsync` command manually with selinux enabled, it 
 
 # Final notes
 
-I use these scripts on Fedora systems (Workstation edition, not Silverblue) where I have my ESPs mounted to /boot@{a,b} and these partitions contain both the bootloader ([systemd-boot](https://www.freedesktop.org/wiki/Software/systemd/systemd-boot/)) and the kernel+initramfs. This configuration is recommended by the [Boot Loader Specification](https://systemd.io/BOOT_LOADER_SPECIFICATION/) which is part of the systemd project.
+I use these scripts on Fedora systems (Workstation edition, not Silverblue) where I have my ESPs mounted to ESP_ROOT@{a,b} and these partitions contain both the bootloader ([systemd-boot](https://www.freedesktop.org/wiki/Software/systemd/systemd-boot/)) and the kernel+initramfs. This configuration is recommended by the [Boot Loader Specification](https://systemd.io/BOOT_LOADER_SPECIFICATION/) which is part of the systemd project.
 
 The GRUB bootloader is known to have problems with this configuration because it attempts to put a symlink below /boot. I have not tested these scripts with GRUB and I do not expect that they will work (properly) with GRUB. Feel free to try and get this to work with GRUB if you like, but my personal recommendation is to switch to using systemd-boot if possible. Please do not send pull requests to integrate GRUB compatibility features. I want to keep these scripts as simple as possible (no GRUB hacks please).
 

--- a/bootbind
+++ b/bootbind
@@ -6,13 +6,13 @@ set -e
 shopt -s dotglob
 shopt -s lastpipe
 
-if mountpoint -q /boot; then
-	echo "/boot is already mounted, aborting..." 1>&2
+if mountpoint -q ${ESP_ROOT}; then
+	echo "${ESP_ROOT} is already mounted, aborting..." 1>&2
 	exit 1
 fi
 
-if ls /boot/* &> /dev/null; then
-	echo "/boot is not empty, aborting..." 1>&2
+if ls ${ESP_ROOT}/* &> /dev/null; then
+	echo "${ESP_ROOT} is not empty, aborting..." 1>&2
 	exit 1
 fi
 
@@ -34,15 +34,15 @@ if [[ -z $UUID ]]; then
 	exit 1
 fi
 
-findmnt -n -l --source "PARTUUID=$UUID" --output "target" | grep -m 1 "^/boot@[a-z]$" | read TRGT
+findmnt -n -l --source "PARTUUID=$UUID" --output "target" | grep -m 1 "^${ESP_ROOT}@[a-z]$" | read TRGT
 if [[ -z $TRGT ]]; then
-	echo "failed to find mountpoint of form /boot@[a-z] for current esp, aborting..." 1>&2
+	echo "failed to find mountpoint of form ${ESP_ROOT}@[a-z] for current esp, aborting..." 1>&2
 	exit 1
 fi
 
-mkdir -p /boot
+mkdir -p ${ESP_ROOT}
 
-chmod 0000 /boot &> /dev/null || true
-chcon -u system_u -r object_r -t boot_t -l s0 /boot &> /dev/null || true
+chmod 0000 ${ESP_ROOT} &> /dev/null || true
+chcon -u system_u -r object_r -t boot_t -l s0 ${ESP_ROOT} &> /dev/null || true
 
-mount -o bind $TRGT /boot
+mount -o bind $TRGT ${ESP_ROOT}

--- a/bootbind.service
+++ b/bootbind.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=bind mount currently-booted ESP to /boot
+Description=bind mount currently-booted ESP to ${ESP_ROOT}
 ConditionFileIsExecutable=/etc/bootsync/bootbind
 DefaultDependencies=no
 Conflicts=shutdown.target

--- a/bootsync
+++ b/bootsync
@@ -9,13 +9,13 @@ TEMPDIR=''
 function cleanup { [[ -n "$TEMPDIR" ]] && rm -rf $TEMPDIR; }
 trap cleanup exit
 
-if ! mountpoint -q /boot; then
-	echo "/boot is not a mountpoint, aborting..." 1>&2
+if ! mountpoint -q ${ESP_ROOT}; then
+	echo "${ESP_ROOT} is not a mountpoint, aborting..." 1>&2
 	exit 1
 fi
 
-if ! [[ -d /boot/loader ]]; then
-	echo "directory /boot/loader not found, aborting..." 1>&2
+if ! [[ -d ${ESP_ROOT}/loader ]]; then
+	echo "directory ${ESP_ROOT}/loader not found, aborting..." 1>&2
 	exit 1
 fi
 
@@ -26,15 +26,15 @@ if [[ -z $MACHINE_ID ]]; then
 fi
 
 ls -v /lib/modules | tail -n 1 | read LASTKRN
-if ! [[ -e /boot/$MACHINE_ID/$LASTKRN ]]; then
-	echo "$MACHINE_ID/$LASTKRN not found under /boot, aborting..." 1>&2
+if ! [[ -e ${ESP_ROOT}/$MACHINE_ID/$LASTKRN ]]; then
+	echo "$MACHINE_ID/$LASTKRN not found under ${ESP_ROOT}, aborting..." 1>&2
 	exit 1
 fi
 
-findmnt -n -l --output source /boot | read SRC
-findmnt -n -l --output target $SRC | grep -m 1 "^/boot@[a-z]$" | read TGT
+findmnt -n -l --output source ${ESP_ROOT} | read SRC
+findmnt -n -l --output target $SRC | grep -m 1 "^${ESP_ROOT}@[a-z]$" | read TGT
 if [[ -z $TGT ]]; then
-	echo "/boot does not appear to be a bind mount of /boot@[a-z], aborting..." 1>&2
+	echo "${ESP_ROOT} does not appear to be a bind mount of ${ESP_ROOT}@[a-z], aborting..." 1>&2
 	exit 1
 fi
 
@@ -46,7 +46,7 @@ fi
 
 mktemp -d | read TEMPDIR
 touch $TEMPDIR/$LASTKRN
-for m in $(ls -d /boot@[a-z]); do
+for m in $(ls -d ${ESP_ROOT}@[a-z]); do
 	mountpoint -q $m || continue
 	[[ $m == $TGT ]] && continue
 
@@ -59,5 +59,5 @@ for m in $(ls -d /boot@[a-z]); do
 		continue
 	fi
 
-	rsync $VERBOSITY -r --delete --include="*/" --include="**$MACHINE_ID**" --exclude="*" /boot/ $m
+	rsync $VERBOSITY -r --delete --include="*/" --include="**$MACHINE_ID**" --exclude="*" ${ESP_ROOT}/ $m
 done

--- a/bootsync.service
+++ b/bootsync.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=synchronize ESPs on mirrored-disk systems
 ConditionFileIsExecutable=/etc/bootsync/bootsync
-AssertPathIsMountPoint=/boot
+AssertPathIsMountPoint=${ESP_ROOT}
 After=local-fs.target
 After=bootbind.service
 


### PR DESCRIPTION
If the system has the ESP(s) mounted at a path other than /boot, the user can specify 'esp_root=<path>' while invoking the Makefile targets to specify the necessary path.

Closes #1.